### PR TITLE
Renamed env variables to be the same as the ones the frontend uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Prerequisites to Run Integration Tests
 
     * Set up the following environment variables (possibly in your `launchpad-missioncontrol-env.sh` file): 
       ```
-        export LAUNCHPAD_MISSIONCONTROL_KEYCLOAK_URL=http://sso.prod-preview.openshift.io
-        export LAUNCHPAD_MISSIONCONTROL_KEYCLOAK_REALM=fabric8
+        export LAUNCHPAD_KEYCLOAK_URL=http://sso.prod-preview.openshift.io
+        export LAUNCHPAD_KEYCLOAK_REALM=fabric8
       ```
     IMPORTANT: Mission Control will not use the keycloak server if you provide the following environment variables:
       ```    
@@ -111,8 +111,8 @@ export LAUNCHPAD_MISSIONCONTROL_GITHUB_USERNAME=<replace with your github userna
 export LAUNCHPAD_MISSIONCONTROL_GITHUB_TOKEN=<replace with your personal token (see step 1)>
 export LAUNCHPAD_MISSIONCONTROL_OPENSHIFT_API_URL=`minishift console --url`
 export LAUNCHPAD_MISSIONCONTROL_OPENSHIFT_CONSOLE_URL=`minishift console --url`
-export LAUNCHPAD_MISSIONCONTROL_KEYCLOAK_URL=http://sso.prod-preview.openshift.io
-export LAUNCHPAD_MISSIONCONTROL_KEYCLOAK_REALM=fabric8
+export LAUNCHPAD_KEYCLOAK_URL=http://sso.prod-preview.openshift.io
+export LAUNCHPAD_KEYCLOAK_REALM=fabric8
 export LAUNCHPAD_MISSIONCONTROL_OPENSHIFT_USERNAME=developer
 export LAUNCHPAD_MISSIONCONTROL_OPENSHIFT_PASSWORD=developer
 unset LAUNCHPAD_MISSIONCONTROL_OPENSHIFT_TOKEN

--- a/services/keycloak-service-impl/src/main/java/io/openshift/appdev/missioncontrol/service/keycloak/impl/KeycloakServiceImpl.java
+++ b/services/keycloak-service-impl/src/main/java/io/openshift/appdev/missioncontrol/service/keycloak/impl/KeycloakServiceImpl.java
@@ -25,9 +25,9 @@ public class KeycloakServiceImpl implements KeycloakService {
 
     private static final String TOKEN_URL_TEMPLATE = "%s/auth/realms/%s/broker/%s/token";
 
-    public static final String LAUNCHPAD_MISSIONCONTROL_KEYCLOAK_URL = "LAUNCHPAD_MISSIONCONTROL_KEYCLOAK_URL";
+    public static final String LAUNCHPAD_MISSIONCONTROL_KEYCLOAK_URL = "LAUNCHPAD_KEYCLOAK_URL";
 
-    public static final String LAUNCHPAD_MISSIONCONTROL_KEYCLOAK_REALM = "LAUNCHPAD_MISSIONCONTROL_KEYCLOAK_REALM";
+    public static final String LAUNCHPAD_MISSIONCONTROL_KEYCLOAK_REALM = "LAUNCHPAD_KEYCLOAK_REALM";
 
     private final String gitHubURL;
 


### PR DESCRIPTION
Also see https://github.com/openshiftio/launchpad-frontend/pull/57

- [ ] Have you created an [issue](https://github.com/redhat-kontinuity/catapult/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/redhat-kontinuity/catapult/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----

