### PR TITLE
Add an updated nodejs jenkins slave.

### DIFF
--- a/services/openshift-service-impl/src/main/resources/pipeline-template.yml
+++ b/services/openshift-service-impl/src/main/resources/pipeline-template.yml
@@ -56,3 +56,13 @@ objects:
       role: jenkins-slave
   spec:
     dockerImageRepository: openshiftio/launchpad-jenkins-slave
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: launchpad-nodejs
+    annotations:
+      openshift.io/display-name: 'Jenkins 2 CentOS 7 NodeJS'
+    labels:
+      role: jenkins-slave
+  spec:
+    dockerImageRepository: bucharestgold/jenkins-slave-nodejs-centos7


### PR DESCRIPTION
* Include node 8.1.4 and npm 5.3.0

- [] Have you created an [issue](https://github.com/openshiftio/launchpad-missioncontrol/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openshiftio/launchpad-missioncontrol/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----


This adds the nodejs jenkins slave that we forked and updated with the latest node and npm versions.  

This is part of a couple different commits to get the nodejs runtime integrated 

dev docs - https://github.com/openshiftio/appdev-documentation/pull/375
booster-catalog update - https://github.com/openshiftio/booster-catalog/pull/61