### PR TITLE
Fixes #264: Introduced OpenShiftClusterRegistry and OpenShiftResource

### DIFF
--- a/core/core-api/src/main/java/io/openshift/appdev/missioncontrol/core/api/CreateProjectileBuilder.java
+++ b/core/core-api/src/main/java/io/openshift/appdev/missioncontrol/core/api/CreateProjectileBuilder.java
@@ -19,8 +19,8 @@ import io.openshift.appdev.missioncontrol.base.identity.Identity;
  * Each property's valid value and purpose is documented in its setter method.
  */
 public class CreateProjectileBuilder extends ProjectileBuilder {
-    CreateProjectileBuilder(Identity gitHubIdentity, Identity openShiftIdentity, String openShiftProjectName) {
-        super(gitHubIdentity, openShiftIdentity, openShiftProjectName);
+    CreateProjectileBuilder(Identity gitHubIdentity, Identity openShiftIdentity, String openShiftProjectName, String openShiftClusterName) {
+        super(gitHubIdentity, openShiftIdentity, openShiftProjectName, openShiftClusterName);
     }
 
     private Path projectLocation;
@@ -111,7 +111,7 @@ public class CreateProjectileBuilder extends ProjectileBuilder {
 
     /**
      * Sets the name of the mission of the booster associated with this builder
-     * 
+     *
      * @param mission
      * @return
      */
@@ -126,7 +126,7 @@ public class CreateProjectileBuilder extends ProjectileBuilder {
 
     /**
      * Sets the name of the runtime of the booster associated with this builder
-     * 
+     *
      * @param runtime
      * @return
      */

--- a/core/core-api/src/main/java/io/openshift/appdev/missioncontrol/core/api/ForkProjectileBuilder.java
+++ b/core/core-api/src/main/java/io/openshift/appdev/missioncontrol/core/api/ForkProjectileBuilder.java
@@ -1,9 +1,9 @@
 package io.openshift.appdev.missioncontrol.core.api;
 
-import io.openshift.appdev.missioncontrol.base.identity.Identity;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import io.openshift.appdev.missioncontrol.base.identity.Identity;
 
 /**
  * DSL builder for creating {@link ForkProjectile} objects.  Responsible for
@@ -17,8 +17,8 @@ import java.util.regex.Pattern;
  * Each property's valid value and purpose is documented in its setter method.
  */
 public class ForkProjectileBuilder extends ProjectileBuilder {
-    ForkProjectileBuilder(Identity gitHubAccessToken, Identity openshiftAccessToken, String openShiftProjectName) {
-        super(gitHubAccessToken, openshiftAccessToken, openShiftProjectName);
+    ForkProjectileBuilder(Identity gitHubAccessToken, Identity openshiftAccessToken, String openShiftProjectName, String openShiftClusterName) {
+        super(gitHubAccessToken, openshiftAccessToken, openShiftProjectName, openShiftClusterName);
     }
 
     private static final Pattern REPO_PATTERN = Pattern.compile("^[a-zA-Z_0-9\\-]+/[a-zA-Z_0-9\\-]+");

--- a/core/core-api/src/main/java/io/openshift/appdev/missioncontrol/core/api/Projectile.java
+++ b/core/core-api/src/main/java/io/openshift/appdev/missioncontrol/core/api/Projectile.java
@@ -20,6 +20,8 @@ public abstract class Projectile {
 
     private final String openShiftProjectName;
 
+    private final String openShiftClusterName;
+
     /**
      * Package-level access; to be invoked by {@link ProjectileBuilder}
      * and all precondition checks are its responsibility
@@ -28,6 +30,7 @@ public abstract class Projectile {
         this.gitHubIdentity = builder.getGitHubIdentity();
         this.openShiftIdentity = builder.getOpenShiftIdentity();
         this.openShiftProjectName = builder.getOpenShiftProjectName();
+        this.openShiftClusterName = builder.getOpenShiftClusterName();
     }
 
     /**
@@ -56,5 +59,13 @@ public abstract class Projectile {
      */
     public String getOpenShiftProjectName() {
         return openShiftProjectName;
+    }
+
+    /**
+     *
+     * @return The OpenShift cluster to deploy
+     */
+    public String getOpenShiftClusterName() {
+        return openShiftClusterName;
     }
 }

--- a/core/core-api/src/main/java/io/openshift/appdev/missioncontrol/core/api/ProjectileBuilder.java
+++ b/core/core-api/src/main/java/io/openshift/appdev/missioncontrol/core/api/ProjectileBuilder.java
@@ -23,10 +23,11 @@ public class ProjectileBuilder {
         // No external instances
     }
 
-    ProjectileBuilder(Identity gitHubIdentity, Identity openShiftIdentity, String openShiftProjectName) {
+    ProjectileBuilder(Identity gitHubIdentity, Identity openShiftIdentity, String openShiftProjectName, String openShiftClusterName) {
         this.gitHubIdentity = gitHubIdentity;
         this.openShiftIdentity = openShiftIdentity;
         this.openShiftProjectName = openShiftProjectName;
+        this.openShiftClusterName = openShiftClusterName;
     }
 
     private Identity gitHubIdentity;
@@ -37,6 +38,11 @@ public class ProjectileBuilder {
      * the name of OpenShift project to create.
      */
     private String openShiftProjectName;
+
+    /**
+     * The OpenShift cluster name
+     */
+    private String openShiftClusterName;
 
     /**
      * Creates and returns a new instance with uninitialized values
@@ -106,12 +112,16 @@ public class ProjectileBuilder {
         return openShiftProjectName;
     }
 
+    public String getOpenShiftClusterName() {
+        return openShiftClusterName;
+    }
+
     public CreateProjectileBuilder createType() {
-        return new CreateProjectileBuilder(getGitHubIdentity(), getOpenShiftIdentity(), getOpenShiftProjectName());
+        return new CreateProjectileBuilder(getGitHubIdentity(), getOpenShiftIdentity(), getOpenShiftProjectName(), getOpenShiftClusterName());
     }
 
     public ForkProjectileBuilder forkType() {
-        return new ForkProjectileBuilder(getGitHubIdentity(), getOpenShiftIdentity(), getOpenShiftProjectName());
+        return new ForkProjectileBuilder(getGitHubIdentity(), getOpenShiftIdentity(), getOpenShiftProjectName(), getOpenShiftClusterName());
     }
 
 
@@ -128,7 +138,7 @@ public class ProjectileBuilder {
                                final Object value) throws IllegalStateException {
         assert name != null && !name.isEmpty() : "name is required";
 
-        if (value == null || (value instanceof String && ((String)value).isEmpty())) {
+        if (value == null || (value instanceof String && ((String) value).isEmpty())) {
             throw new IllegalStateException(name + " must be specified");
         }
     }

--- a/services/keycloak-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/keycloak/api/KeycloakService.java
+++ b/services/keycloak-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/keycloak/api/KeycloakService.java
@@ -1,5 +1,7 @@
 package io.openshift.appdev.missioncontrol.service.keycloak.api;
 
+import java.util.Optional;
+
 import io.openshift.appdev.missioncontrol.base.identity.Identity;
 
 /**
@@ -11,6 +13,8 @@ public interface KeycloakService {
 
     /**
      * Returns the Openshift v3 {@link Identity} used for authenticating with the Openshift console
+     *
+     * This returns the
      *
      * @param token the keycloak access token
      * @return the openshift v3 token assigned to the given keycloak access token
@@ -24,4 +28,13 @@ public interface KeycloakService {
      * @return the github Identity token assigned to the given keycloak access token
      */
     Identity getGitHubIdentity(String token);
+
+    /**
+     * Grabs the {@link Identity} for the specified provider
+     *
+     * @param provider The identity provider to use
+     * @param token    the keycloak access token
+     * @return an {@link Optional} containing an {@link Identity}
+     */
+    Optional<Identity> getIdentity(String provider, String token);
 }

--- a/services/keycloak-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/keycloak/api/KeycloakService.java
+++ b/services/keycloak-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/keycloak/api/KeycloakService.java
@@ -14,8 +14,6 @@ public interface KeycloakService {
     /**
      * Returns the Openshift v3 {@link Identity} used for authenticating with the Openshift console
      *
-     * This returns the
-     *
      * @param token the keycloak access token
      * @return the openshift v3 token assigned to the given keycloak access token
      */

--- a/services/openshift-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/api/OpenShiftCluster.java
+++ b/services/openshift-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/api/OpenShiftCluster.java
@@ -1,0 +1,63 @@
+package io.openshift.appdev.missioncontrol.service.openshift.api;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class OpenShiftCluster {
+
+    private final String id;
+
+    private final String apiUrl;
+
+    private final String consoleUrl;
+
+    public OpenShiftCluster(String id, String apiUrl, String consoleUrl) {
+        assert id != null : "id is required";
+        assert apiUrl != null : "apiUrl is required";
+        assert consoleUrl != null : "consoleUrl is required";
+        this.id = id;
+        this.apiUrl = apiUrl;
+        this.consoleUrl = consoleUrl;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getApiUrl() {
+        return apiUrl;
+    }
+
+    public String getConsoleUrl() {
+        return consoleUrl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        OpenShiftCluster that = (OpenShiftCluster) o;
+
+        if (!id.equals(that.id)) return false;
+        if (!apiUrl.equals(that.apiUrl)) return false;
+        return consoleUrl.equals(that.consoleUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id.hashCode();
+        result = 31 * result + apiUrl.hashCode();
+        result = 31 * result + consoleUrl.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "OpenShiftCluster{" +
+                "id='" + id + '\'' +
+                ", apiUrl='" + apiUrl + '\'' +
+                ", consoleUrl='" + consoleUrl + '\'' +
+                '}';
+    }
+}

--- a/services/openshift-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/api/OpenShiftClusterRegistry.java
+++ b/services/openshift-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/api/OpenShiftClusterRegistry.java
@@ -1,0 +1,42 @@
+package io.openshift.appdev.missioncontrol.service.openshift.api;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Holds a registry of supported OpenShift clusters
+ *
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public interface OpenShiftClusterRegistry {
+
+    /**
+     * The supported clusters in this environment
+     *
+     * @return a {@link Set} of {@link OpenShiftCluster} objects
+     */
+    Set<OpenShiftCluster> getClusters();
+
+    /**
+     * @return the default {@link OpenShiftCluster} configuration
+     */
+    OpenShiftCluster getDefault();
+
+    /**
+     * Find an {@link OpenShiftCluster} by its id
+     *
+     * @param id the desired {@link OpenShiftCluster} id. Returns {@link OpenShiftClusterRegistry#getDefault()} if null
+     * @return an {@link Optional} with the possible {@link OpenShiftCluster}
+     */
+    default Optional<OpenShiftCluster> findClusterById(final String id) {
+        if (id == null) {
+            return Optional.of(getDefault());
+        }
+        return getClusters()
+                .stream()
+                .filter(c -> Objects.equals(c.getId(), id))
+                .findFirst();
+    }
+
+}

--- a/services/openshift-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/api/OpenShiftEnvVarSysPropNames.java
+++ b/services/openshift-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/api/OpenShiftEnvVarSysPropNames.java
@@ -6,8 +6,13 @@ package io.openshift.appdev.missioncontrol.service.openshift.api;
  */
 public interface OpenShiftEnvVarSysPropNames {
 
-    static String OPENSHIFT_API_URL = "LAUNCHPAD_MISSIONCONTROL_OPENSHIFT_API_URL";
+    String OPENSHIFT_API_URL = "LAUNCHPAD_MISSIONCONTROL_OPENSHIFT_API_URL";
 
-    static String OPENSHIFT_CONSOLE_URL = "LAUNCHPAD_MISSIONCONTROL_OPENSHIFT_CONSOLE_URL";
+    String OPENSHIFT_CONSOLE_URL = "LAUNCHPAD_MISSIONCONTROL_OPENSHIFT_CONSOLE_URL";
+
+    /**
+     * A YAML file containing the supported openshift clusters
+     */
+    String OPENSHIFT_CONFIG_FILE = "LAUNCHPAD_MISSIONCONTROL_OPENSHIFT_CONFIG_FILE";
 
 }

--- a/services/openshift-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/api/OpenShiftServiceFactory.java
+++ b/services/openshift-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/api/OpenShiftServiceFactory.java
@@ -18,10 +18,10 @@ public interface OpenShiftServiceFactory {
     OpenShiftService create(Identity identity);
 
     /**
-     * Returns an {@link OpenShiftService} given it's API and Console URLs and OAuth token
+     * Returns an {@link OpenShiftService} given it's {@link OpenShiftCluster} and OAuth token
      *
      * @param identity an identity
      * @return an {@link OpenShiftService}
      */
-    OpenShiftService create(String apiUrl, String consoleUrl, Identity identity);
+    OpenShiftService create(OpenShiftCluster cluster, Identity identity);
 }

--- a/services/openshift-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/api/OpenShiftSettings.java
+++ b/services/openshift-service-api/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/api/OpenShiftSettings.java
@@ -41,6 +41,16 @@ public class OpenShiftSettings {
         return getOpenShiftUrl(OpenShiftEnvVarSysPropNames.OPENSHIFT_CONSOLE_URL);
     }
 
+    /**
+     * The URL to the supported OpenShift configs
+     *
+     * @return
+     */
+    public static String getOpenShiftConfigFileUrl() {
+        return System.getProperty(OpenShiftEnvVarSysPropNames.OPENSHIFT_CONFIG_FILE,
+                                  System.getenv(OpenShiftEnvVarSysPropNames.OPENSHIFT_CONFIG_FILE));
+    }
+
     private static String getOpenShiftUrl(final String envVarOrSysPropName) {
         assert envVarOrSysPropName != null && !envVarOrSysPropName.isEmpty();
         if (isSystemPropertySet(envVarOrSysPropName)) {

--- a/services/openshift-service-impl/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/impl/OpenShiftClusterConstructor.java
+++ b/services/openshift-service-impl/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/impl/OpenShiftClusterConstructor.java
@@ -1,0 +1,42 @@
+package io.openshift.appdev.missioncontrol.service.openshift.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftCluster;
+import org.yaml.snakeyaml.constructor.AbstractConstruct;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.nodes.MappingNode;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.NodeId;
+import org.yaml.snakeyaml.nodes.SequenceNode;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class OpenShiftClusterConstructor extends Constructor {
+
+    public OpenShiftClusterConstructor() {
+        this.yamlClassConstructors.put(NodeId.sequence, new ConstructCluster());
+    }
+
+    private class ConstructCluster extends AbstractConstruct {
+
+        @Override
+        public List<OpenShiftCluster> construct(Node node) {
+            List<OpenShiftCluster> clusters = new ArrayList<>();
+            SequenceNode sequenceNode = (SequenceNode) node;
+            for (Node n : sequenceNode.getValue()) {
+                MappingNode mapNode = (MappingNode) n;
+                Map<Object, Object> valueMap = constructMapping(mapNode);
+                String id = (String) valueMap.get("id");
+                String apiUrl = (String) valueMap.get("apiUrl");
+                String consoleUrl = (String) valueMap.get("consoleUrl");
+                clusters.add(new OpenShiftCluster(id, apiUrl, consoleUrl));
+            }
+            return clusters;
+        }
+    }
+
+}

--- a/services/openshift-service-impl/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/impl/OpenShiftClusterRegistryImpl.java
+++ b/services/openshift-service-impl/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/impl/OpenShiftClusterRegistryImpl.java
@@ -1,0 +1,63 @@
+package io.openshift.appdev.missioncontrol.service.openshift.impl;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Singleton;
+
+import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftCluster;
+import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftClusterRegistry;
+import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftSettings;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+@Singleton
+public class OpenShiftClusterRegistryImpl implements OpenShiftClusterRegistry {
+
+    private final Set<OpenShiftCluster> CLUSTERS;
+
+    private final OpenShiftCluster defaultCluster;
+
+    public OpenShiftClusterRegistryImpl() {
+        Set<OpenShiftCluster> clusters = new LinkedHashSet<>();
+        String configFileUrl = OpenShiftSettings.getOpenShiftConfigFileUrl();
+        if (configFileUrl == null) {
+            defaultCluster = new OpenShiftCluster("openshift-v3",
+                                                  OpenShiftSettings.getOpenShiftApiUrl(),
+                                                  OpenShiftSettings.getOpenShiftConsoleUrl());
+            clusters.add(defaultCluster);
+        } else {
+            Path configFilePath = Paths.get(configFileUrl);
+            try (BufferedReader reader = Files.newBufferedReader(configFilePath)) {
+                Yaml yaml = new Yaml(new OpenShiftClusterConstructor());
+                List<OpenShiftCluster> configClusters = (List<OpenShiftCluster>) yaml.loadAs(reader, List.class);
+                assert configClusters != null : "Config file " + configFileUrl + " is an invalid YAML file";
+                assert configClusters.size() > 0 : "No entries found in " + configFileUrl;
+                clusters.addAll(configClusters);
+                defaultCluster = configClusters.get(0);
+            } catch (IOException e) {
+                throw new IllegalStateException("Error while reading OpenShift Config file", e);
+            }
+        }
+        CLUSTERS = Collections.unmodifiableSet(clusters);
+    }
+
+    @Override
+    public OpenShiftCluster getDefault() {
+        return defaultCluster;
+    }
+
+    @Override
+    public Set<OpenShiftCluster> getClusters() {
+        return CLUSTERS;
+    }
+}

--- a/services/openshift-service-impl/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/impl/fabric8/openshift/client/Fabric8OpenShiftServiceFactory.java
+++ b/services/openshift-service-impl/src/main/java/io/openshift/appdev/missioncontrol/service/openshift/impl/fabric8/openshift/client/Fabric8OpenShiftServiceFactory.java
@@ -3,11 +3,13 @@ package io.openshift.appdev.missioncontrol.service.openshift.impl.fabric8.opensh
 import java.util.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import io.openshift.appdev.missioncontrol.base.identity.Identity;
+import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftCluster;
+import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftClusterRegistry;
 import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftService;
 import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftServiceFactory;
-import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftSettings;
 
 /**
  * {@link OpenShiftServiceFactory} implementation
@@ -19,6 +21,9 @@ public class Fabric8OpenShiftServiceFactory implements OpenShiftServiceFactory {
 
     private Logger log = Logger.getLogger(Fabric8OpenShiftServiceFactory.class.getName());
 
+    @Inject
+    OpenShiftClusterRegistry clusterRegistry;
+
     /**
      * Creates a new {@link OpenShiftService} with the specified credentials
      *
@@ -28,9 +33,7 @@ public class Fabric8OpenShiftServiceFactory implements OpenShiftServiceFactory {
      */
     @Override
     public Fabric8OpenShiftServiceImpl create(Identity identity) {
-        final String apiUrl = OpenShiftSettings.getOpenShiftApiUrl();
-        final String consoleUrl = OpenShiftSettings.getOpenShiftConsoleUrl();
-        return create(apiUrl, consoleUrl, identity);
+        return create(clusterRegistry.getDefault(), identity);
     }
 
     /**
@@ -41,21 +44,13 @@ public class Fabric8OpenShiftServiceFactory implements OpenShiftServiceFactory {
      * @throws IllegalArgumentException If the {@code identity} is not specified
      */
     @Override
-    public Fabric8OpenShiftServiceImpl create(String apiUrl, String consoleUrl, Identity identity) {
+    public Fabric8OpenShiftServiceImpl create(final OpenShiftCluster openShiftCluster, final Identity identity) {
         if (identity == null) {
             throw new IllegalArgumentException("identity is required");
         }
-
-        // Precondition checks
-        if (apiUrl == null) {
-            throw new IllegalArgumentException("openshiftUrl is required");
-        }
-        if (consoleUrl == null) {
-            throw new IllegalArgumentException("openshiftConsoleUrl is required");
-        }
-
+        assert openShiftCluster != null: "OpenShiftCluster is required";
         // Create and return
-        log.finest(() -> "Created backing OpenShift client for " + apiUrl);
-        return new Fabric8OpenShiftServiceImpl(apiUrl, consoleUrl, identity);
+        log.finest(() -> "Created backing OpenShift client for " + openShiftCluster.getApiUrl());
+        return new Fabric8OpenShiftServiceImpl(openShiftCluster.getApiUrl(), openShiftCluster.getConsoleUrl(), identity);
     }
 }

--- a/services/openshift-service-impl/src/test/java/io/openshift/appdev/missioncontrol/service/openshift/impl/OpenShiftClusterRegistryTest.java
+++ b/services/openshift-service-impl/src/test/java/io/openshift/appdev/missioncontrol/service/openshift/impl/OpenShiftClusterRegistryTest.java
@@ -1,0 +1,58 @@
+package io.openshift.appdev.missioncontrol.service.openshift.impl;
+
+import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftCluster;
+import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftClusterRegistry;
+import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftEnvVarSysPropNames;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class OpenShiftClusterRegistryTest {
+
+    private OpenShiftClusterRegistry registry;
+
+    @Before
+    public void setUp() {
+        System.setProperty(OpenShiftEnvVarSysPropNames.OPENSHIFT_CONFIG_FILE, "src/test/resources/openshift-config.yaml");
+        registry = new OpenShiftClusterRegistryImpl();
+    }
+
+    @Test
+    public void testDefaultClusterNeverNull() {
+        assertThat(registry.getDefault()).isNotNull();
+    }
+
+    @Test
+    public void testGetClustersIncludeDefaultCluster() {
+        assertThat(registry.getClusters()).contains(registry.getDefault());
+    }
+
+    @Test
+    public void testGetClustersHasAtLeastTwoItems() {
+        assertThat(registry.getClusters().size()).isGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    public void testFindNullReturnsDefault() {
+        assertThat(registry.findClusterById(null).get()).isSameAs(registry.getDefault());
+    }
+
+    @Test
+    public void testFindOpenshiftOnlineInt() {
+        assertThat(registry.findClusterById("openshift-online-int").get())
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("id", "openshift-online-int")
+                .hasFieldOrPropertyWithValue("apiUrl", "https://api.online-int.openshift.com/")
+                .hasFieldOrPropertyWithValue("consoleUrl", "https://console.online-int.openshift.com/console");
+    }
+
+    @After
+    public void tearDown() {
+        System.getProperties().remove(OpenShiftEnvVarSysPropNames.OPENSHIFT_CONFIG_FILE);
+    }
+}

--- a/services/openshift-service-impl/src/test/resources/openshift-config.yaml
+++ b/services/openshift-service-impl/src/test/resources/openshift-config.yaml
@@ -1,0 +1,6 @@
+- id: openshift-v3
+  apiUrl: https://api.starter-us-east-1.openshift.com/
+  consoleUrl: https://console.starter-us-east-1.openshift.com/console/
+- id: openshift-online-int
+  apiUrl: https://api.online-int.openshift.com/
+  consoleUrl: https://console.online-int.openshift.com/console

--- a/web/src/main/java/io/openshift/appdev/missioncontrol/web/api/HttpEndpoints.java
+++ b/web/src/main/java/io/openshift/appdev/missioncontrol/web/api/HttpEndpoints.java
@@ -7,6 +7,8 @@ import javax.inject.Inject;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
+import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftCluster;
+
 /**
  * Defines our HTTP endpoints as singletons
  *
@@ -26,12 +28,16 @@ public class HttpEndpoints extends Application {
     @Inject
     private ValidationResource userResource;
 
+    @Inject
+    private OpenShiftResource openShiftResource;
+
     @Override
     public Set<Object> getSingletons() {
         final Set<Object> singletons = new HashSet<>();
         singletons.add(missionControlResource);
         singletons.add(healthResource);
         singletons.add(userResource);
+        singletons.add(openShiftResource);
 
         CorsFilter corsFilter = new CorsFilter();
         corsFilter.getAllowedOrigins().add("*");

--- a/web/src/main/java/io/openshift/appdev/missioncontrol/web/api/OpenShiftResource.java
+++ b/web/src/main/java/io/openshift/appdev/missioncontrol/web/api/OpenShiftResource.java
@@ -1,0 +1,59 @@
+package io.openshift.appdev.missioncontrol.web.api;
+
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+import io.openshift.appdev.missioncontrol.service.keycloak.api.KeycloakService;
+import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftCluster;
+import io.openshift.appdev.missioncontrol.service.openshift.api.OpenShiftClusterRegistry;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+@Path(OpenShiftResource.PATH_RESOURCE)
+@ApplicationScoped
+public class OpenShiftResource extends AbstractResource {
+
+    static final String PATH_RESOURCE = "/openshift";
+
+    @Inject
+    OpenShiftClusterRegistry clusterRegistry;
+
+    @Inject
+    Instance<KeycloakService> keycloakServiceInstance;
+
+    @GET
+    @Path("/clusters")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonArray getSupportedOpenShiftClusters(@HeaderParam(HttpHeaders.AUTHORIZATION) final String authorization) {
+        JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+        Set<OpenShiftCluster> clusters = clusterRegistry.getClusters();
+        if (useDefaultIdentities()) {
+            // Return all identities
+            clusters
+                    .stream()
+                    .map(OpenShiftCluster::getId)
+                    .forEach(arrayBuilder::add);
+        } else {
+            final KeycloakService keycloakService = this.keycloakServiceInstance.get();
+            clusters.stream().map(OpenShiftCluster::getId)
+                    .forEach(clusterId ->
+                                     keycloakService.getIdentity(clusterId, authorization)
+                                             .ifPresent(token -> arrayBuilder.add(clusterId)));
+        }
+
+        return arrayBuilder.build();
+    }
+}

--- a/web/src/main/java/io/openshift/appdev/missioncontrol/web/api/UploadForm.java
+++ b/web/src/main/java/io/openshift/appdev/missioncontrol/web/api/UploadForm.java
@@ -38,6 +38,10 @@ public class UploadForm {
     @PartType(MediaType.APPLICATION_FORM_URLENCODED)
     private String runtime;
 
+    @FormParam("openShiftCluster")
+    @PartType(MediaType.APPLICATION_FORM_URLENCODED)
+    private String openShiftCluster;
+
     public String getGitHubRepositoryDescription() {
         return gitHubRepositoryDescription;
     }
@@ -84,5 +88,13 @@ public class UploadForm {
 
     public void setOpenShiftProjectName(String openShiftProjectName) {
         this.openShiftProjectName = openShiftProjectName;
+    }
+
+    public String getOpenShiftCluster() {
+        return openShiftCluster;
+    }
+
+    public void setOpenShiftCluster(String openShiftCluster) {
+        this.openShiftCluster = openShiftCluster;
     }
 }


### PR DESCRIPTION
Also, the OpenShiftServiceFactory now accepts an OpenShiftCluster when creating an OpenShiftService instance.

Support OPENSHIFT_CONFIG_FILE

Add KeyCloakService.getIdentity(String provider, String token)

Add OpenShiftResource